### PR TITLE
Omit root graph name unless explicitly assigned via graphviz.name attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ Once [installed](#install), let's build and display a sample graph:
 
 ````php
 $graph = new Fhaculty\Graph\Graph();
-// Set graph name to blank to hide default G tooltip for SVG output
-$graph->setAttribute('graphviz.name', '');
 
 $blue = $graph->createVertex('blue');
 $blue->setAttribute('graphviz.color', 'blue');
@@ -100,6 +98,19 @@ $hello->createEdgeTo($world);
 ![html graph example](examples/02-html.png)
 
 See also the [examples](examples/).
+
+Additionally, this library accepts an optional `graphviz.name` attribute that
+will be used as the name (or ID) for the root graph object in the DOT output if
+given. Unless explicitly assigned, this will be omitted by default. It is common
+to assign a `G` here, but usually there should be no need to assign this. Among
+others, this may be used as the title or tooltip in SVG output.
+
+```php
+$graph = new Fhaculty\Graph\Graph();
+$graph->setAttribute('graphviz.name', 'G');
+
+$graph->createVertex('first');
+```
 
 ### Vertex attributes
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Once [installed](#install), let's build and display a sample graph:
 
 ````php
 $graph = new Fhaculty\Graph\Graph();
+// Set graph name to blank to hide default G tooltip for SVG output
+$graph->setAttribute('graphviz.name', '');
 
 $blue = $graph->createVertex('blue');
 $blue->setAttribute('graphviz.color', 'blue');

--- a/src/GraphViz.php
+++ b/src/GraphViz.php
@@ -234,14 +234,11 @@ class GraphViz
          * But the man pages for dot use the term `name` when describing the graph file language.
          */
         $name = $graph->getAttribute('graphviz.name');
-        if ($name === null || $name === 'G') {
-            // don't escape a name of G to maintain default behavior
-            $name = 'G';
-        } else {
-            $name = $this->escapeId($name);
+        if ($name !== null) {
+            $name = $this->escapeId($name) . ' ';
         }
 
-        $script = ($directed ? 'di':'') . 'graph ' . $name . ' {' . self::EOL;
+        $script = ($directed ? 'di':'') . 'graph ' . $name . '{' . self::EOL;
 
         // add global attributes
         $globals = array(

--- a/src/GraphViz.php
+++ b/src/GraphViz.php
@@ -228,7 +228,20 @@ class GraphViz
         $alg = new Directed($graph);
         $directed = $alg->hasDirected();
 
-        $script = ($directed ? 'di':'') . 'graph G {' . self::EOL;
+        /*
+         * The website [http://www.graphviz.org/content/dot-language] uses the term `ID` when displaying
+         * the abstract grammar for the DOT language.
+         * But the man pages for dot use the term `name` when describing the graph file language.
+         */
+        $name = $graph->getAttribute('graphviz.name');
+        if ($name === null || $name === 'G') {
+            // don't escape a name of G to maintain default behavior
+            $name = 'G';
+        } else {
+            $name = $this->escapeId($name);
+        }
+
+        $script = ($directed ? 'di':'') . 'graph ' . $name . ' {' . self::EOL;
 
         // add global attributes
         $globals = array(

--- a/tests/GraphVizTest.php
+++ b/tests/GraphVizTest.php
@@ -18,7 +18,7 @@ class GraphVizTest extends TestCase
         $graph = new Graph();
 
         $expected = <<<VIZ
-graph G {
+graph {
 }
 
 VIZ;
@@ -26,13 +26,13 @@ VIZ;
         $this->assertEquals($expected, $this->graphViz->createScript($graph));
     }
 
-    public  function testGraphExplicitDefaultName()
+    public function testGraphWithName()
     {
         $graph = new Graph();
         $graph->setAttribute('graphviz.name', 'G');
 
                 $expected = <<<VIZ
-graph G {
+graph "G" {
 }
 
 VIZ;
@@ -40,41 +40,13 @@ VIZ;
         $this->assertEquals($expected, $this->graphViz->createScript($graph));
     }
 
-    public  function testGraphName()
+    public function testGraphWithNameWithSpaces()
     {
         $graph = new Graph();
         $graph->setAttribute('graphviz.name', 'My Graph Name');
 
                 $expected = <<<VIZ
 graph "My Graph Name" {
-}
-
-VIZ;
-
-        $this->assertEquals($expected, $this->graphViz->createScript($graph));
-    }
-
-    public  function testGraphBlankName()
-    {
-        $graph = new Graph();
-        $graph->setAttribute('graphviz.name', '');
-
-                $expected = <<<VIZ
-graph "" {
-}
-
-VIZ;
-
-        $this->assertEquals($expected, $this->graphViz->createScript($graph));
-    }
-
-    public  function testGraphNonBlankName()
-    {
-        $graph = new Graph();
-        $graph->setAttribute('graphviz.name', ' ');
-
-                $expected = <<<VIZ
-graph " " {
 }
 
 VIZ;
@@ -89,7 +61,7 @@ VIZ;
         $graph->createVertex('b');
 
         $expected = <<<VIZ
-graph G {
+graph {
   "a"
   "b"
 }
@@ -107,7 +79,7 @@ VIZ;
         $graph->setAttribute('graphviz.edge.color', 'grey');
 
         $expected = <<<VIZ
-graph G {
+graph {
   graph [bgcolor="transparent"]
   node [color="blue"]
   edge [color="grey"]
@@ -125,7 +97,7 @@ VIZ;
         $graph->setAttribute('graphviz.unknown.color', 'red');
 
         $expected = <<<VIZ
-graph G {
+graph {
 }
 
 VIZ;
@@ -144,7 +116,7 @@ VIZ;
 
 
         $expected = <<<VIZ
-graph G {
+graph {
   "a"
   "b¹²³ is; ok\\\\ay, &quot;right&quot;?"
   3
@@ -163,7 +135,7 @@ VIZ;
         $graph->createVertex('a')->createEdgeTo($graph->createVertex('b'));
 
         $expected = <<<VIZ
-digraph G {
+digraph {
   "a" -> "b"
 }
 
@@ -180,7 +152,7 @@ VIZ;
         $graph->createVertex('c')->createEdge($graph->getVertex('b'));
 
         $expected = <<<VIZ
-digraph G {
+digraph {
   "a" -> "b"
   "c" -> "b" [dir="none"]
 }
@@ -200,7 +172,7 @@ VIZ;
         $graph->getVertex('b')->createEdge($graph->getVertex('c'));
 
         $expected = <<<VIZ
-graph G {
+graph {
   "d"
   "a" -- "b"
   "b" -- "c"
@@ -221,7 +193,7 @@ VIZ;
         $graph->createVertex('e')->setBalance(2)->setAttribute('graphviz.label', 'unnamed');
 
         $expected = <<<VIZ
-graph G {
+graph {
   "a" [label="a (+1)"]
   "b" [label="b (0)"]
   "c" [label="c (-1)"]
@@ -244,7 +216,7 @@ VIZ;
         $graph->createVertex('5a')->createEdge($graph->createVertex('5b'))->getAttributeBag()->setAttributes(array('graphviz.a' => 'b', 'graphviz.c' => 'd'));
 
         $expected = <<<VIZ
-graph G {
+graph {
   "1a" -- "1b"
   "2a" -- "2b" [numeric=20]
   "3a" -- "3b" [textual="forty"]
@@ -269,7 +241,7 @@ VIZ;
         $graph->createVertex('7a')->createEdge($graph->createVertex('7b'))->setFlow(70)->setAttribute('graphviz.label', 'prefixed');
 
         $expected = <<<VIZ
-graph G {
+graph {
   "1a" -- "1b"
   "2a" -- "2b" [label=20]
   "3a" -- "3b" [label="0/30"]

--- a/tests/GraphVizTest.php
+++ b/tests/GraphVizTest.php
@@ -26,6 +26,62 @@ VIZ;
         $this->assertEquals($expected, $this->graphViz->createScript($graph));
     }
 
+    public  function testGraphExplicitDefaultName()
+    {
+        $graph = new Graph();
+        $graph->setAttribute('graphviz.name', 'G');
+
+                $expected = <<<VIZ
+graph G {
+}
+
+VIZ;
+
+        $this->assertEquals($expected, $this->graphViz->createScript($graph));
+    }
+
+    public  function testGraphName()
+    {
+        $graph = new Graph();
+        $graph->setAttribute('graphviz.name', 'My Graph Name');
+
+                $expected = <<<VIZ
+graph "My Graph Name" {
+}
+
+VIZ;
+
+        $this->assertEquals($expected, $this->graphViz->createScript($graph));
+    }
+
+    public  function testGraphBlankName()
+    {
+        $graph = new Graph();
+        $graph->setAttribute('graphviz.name', '');
+
+                $expected = <<<VIZ
+graph "" {
+}
+
+VIZ;
+
+        $this->assertEquals($expected, $this->graphViz->createScript($graph));
+    }
+
+    public  function testGraphNonBlankName()
+    {
+        $graph = new Graph();
+        $graph->setAttribute('graphviz.name', ' ');
+
+                $expected = <<<VIZ
+graph " " {
+}
+
+VIZ;
+
+        $this->assertEquals($expected, $this->graphViz->createScript($graph));
+    }
+
     public function testGraphIsolatedVertices()
     {
         $graph = new Graph();


### PR DESCRIPTION
This library now accepts an optional `graphviz.name` attribute that will be used as the name (or ID) for the root graph object in the DOT output if given. Unless explicitly assigned, this will now be omitted by default. It is common to assign a `G` here, but usually there should be no need to assign this. Among others, this may be used as the title or tooltip in SVG output.

Supersedes / closes #20, thank you @rhelms
Resolves / closes #3