### PR TITLE
Fix legacy HHVM build by downgrading Composer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,5 +41,6 @@ jobs:
         with:
           version: lts-3.30
       - run: sudo apt-get -y install graphviz
+      - run: composer self-update --2.2 # downgrade Composer for HHVM
       - run: hhvm $(which composer) install
       - run: hhvm vendor/bin/phpunit


### PR DESCRIPTION
Builds on top of the work done by @clue and the discussion inside reactphp/socket#289.