### PR TITLE
Drop legacy HHVM support due to lack of support and failing test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,16 +31,3 @@ jobs:
         if: ${{ matrix.php >= 7.3 }}
       - run: vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy
         if: ${{ matrix.php < 7.3 }}
-
-  PHPUnit-hhvm:
-    name: PHPUnit (HHVM)
-    runs-on: ubuntu-18.04
-    steps:
-      - uses: actions/checkout@v2
-      - uses: azjezz/setup-hhvm@v1
-        with:
-          version: lts-3.30
-      - run: sudo apt-get -y install graphviz
-      - run: composer self-update --2.2 # downgrade Composer for HHVM
-      - run: hhvm $(which composer) install
-      - run: hhvm vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -423,8 +423,7 @@ $ composer require graphp/graphviz:^0.2.2
 See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.
 
 This project aims to run on any platform and thus does not require any PHP
-extensions and supports running on legacy PHP 5.3 through current PHP 7+ and
-HHVM.
+extensions and supports running on legacy PHP 5.3 through current PHP 7+.
 It's *highly recommended to use PHP 7+* for this project.
 
 The graph drawing feature is powered by the excellent [GraphViz](https://www.graphviz.org)


### PR DESCRIPTION
HHVM does not support PHP anymore and regularly causes our builds to fail, so no reason to keep legacy HHVM support around anymore.

Builds on top of #53, #62 and https://github.com/graphp/graph/pull/211